### PR TITLE
[DEV-9468] Change "Newsroom" to "Site"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can check an example on how to import messages in a Next.js theme in the [Pr
 ### Message descriptors structure
 
 - `actions` -> Labels for buttons or links that trigger a specific action
-- `content` -> Mostly titles for various sections of a Newsroom that are related to the displayed content in some way
+- `content` -> Mostly titles for various sections of a site that are related to the displayed content in some way
 - `errors` -> Messages for error pages (404/500) and form validation errors
 - `search` -> Messages related to the Search module
 - `subscription` -> Messages related to the Subscription module

--- a/src/messageDescriptors/content.ts
+++ b/src/messageDescriptors/content.ts
@@ -46,7 +46,7 @@ export const noStories = defineMessages({
 export const newsroom = defineMessages({
     title: {
         id: 'newsroom.title',
-        defaultMessage: 'Newsroom',
+        defaultMessage: 'Site',
     },
 });
 

--- a/src/messageDescriptors/search.ts
+++ b/src/messageDescriptors/search.ts
@@ -17,7 +17,7 @@ export const search = defineMessages({
     },
     inputLabel: {
         id: 'search.inputLabel',
-        defaultMessage: 'Search site',
+        defaultMessage: 'Search',
     },
     inputHint: {
         id: 'search.inputHint',

--- a/src/messageDescriptors/search.ts
+++ b/src/messageDescriptors/search.ts
@@ -17,7 +17,7 @@ export const search = defineMessages({
     },
     inputLabel: {
         id: 'search.inputLabel',
-        defaultMessage: 'Search newsroom',
+        defaultMessage: 'Search site',
     },
     inputHint: {
         id: 'search.inputHint',


### PR DESCRIPTION
We're replacing the word "Newsroom" with "Site" everywhere, but only labels for now (not variables).

I won't merge it until we decide to push all the changes. Or maybe should I? Because translations take time :)