### PR TITLE
[CARE-3037] Fix typo in French "A propos" → "À propos"

### DIFF
--- a/src/messageFiles/source/fr.json
+++ b/src/messageFiles/source/fr.json
@@ -45,7 +45,7 @@
     "message": "Contact"
   },
   "boilerplate.title": {
-    "message": "A propos de {companyName}"
+    "message": "À propos de {companyName}"
   },
   "categories.title": {
     "message": "Catégories"


### PR DESCRIPTION
### Pull Request Checklist

-   [x] I have ran `npm run intl:extract` after creating/updating the message descriptors.
-   [x] I have committed the message descriptor changes along with the source files changes.
-   [x] I have read [Prezly internal guide for translations](https://www.notion.so/Themes-Translations-i18n-4ae8aa613db146168623dfc65d9e8359)
